### PR TITLE
fix: Remove deprecated left shift operator

### DIFF
--- a/src/main/groovy/org/shikato/gradle/android/coverage/check/AndroidCoverageCheckPlugin.groovy
+++ b/src/main/groovy/org/shikato/gradle/android/coverage/check/AndroidCoverageCheckPlugin.groovy
@@ -28,8 +28,10 @@ class AndroidCoverageCheckPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.extensions.create(EXTENSIONS_NAME, AndroidCoverageCheckExtension);
 
-        project.task(TASK_NAME_TYPE, description: DESCRIPTION_TYPE) << {
-            androidCoverageCheck(project);
+        project.task(TASK_NAME_TYPE, description: DESCRIPTION_TYPE) {
+            doLast {
+              androidCoverageCheck(project);
+            }
         }
     }
 


### PR DESCRIPTION
Android Studio began to complain that the left shift operator would be not be supported in gradle 5.0. I changed the code in my local custom tasks, but it was still complaining about this line in the coverage plugin.

I’ve made what I believe to be the correct change, but I have not written a lot of groovy code, so please be careful to check my change in case I’ve been stupid :-)

I hope this helps. And thanks for such a great library.